### PR TITLE
feat: add tokens + storybook-lite + spec gate

### DIFF
--- a/.github/workflows/spec-gate.yml
+++ b/.github/workflows/spec-gate.yml
@@ -1,0 +1,14 @@
+name: Spec Gate
+on:
+  pull_request:
+    branches: [ main, master ]
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify spec and tokens present
+        run: |
+          test -f spec-driven.md || { echo 'Missing spec-driven.md'; exit 1; }
+          test -f design/tokens.json || { echo 'Missing design/tokens.json'; exit 1; }
+          node -e "JSON.parse(require('fs').readFileSync('design/tokens.json','utf8'))" || { echo 'tokens.json invalid JSON'; exit 1; }

--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,11 @@
+# Design Tokens (Seed)
+
+This seed provides a neutral, accessible token set for rapid POCs and theming experiments. It complements the Spec Kit’s specification-driven workflow.
+
+- tokens.css — CSS variables for quick application in web UIs
+- tokens.json — canonical token export for pipelines and non-CSS consumers
+
+Suggested next steps
+- Add a Storybook (html-vite) to preview components and BOCC shell
+- Export tokens in multiple formats (CSS, JSON, TS) via a small build script
+- Wire a CI check to ensure token changes are reviewed alongside specs

--- a/design/storybook/index.html
+++ b/design/storybook/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>BosonIT Spec Kit — Storybook (Lite)</title>
+    <link rel="stylesheet" href="../tokens.css" />
+    <style>
+      body{ background:var(--color-bg); color:var(--color-fg); font-family:var(--font-sans); margin:0 }
+      .shell{ max-width:1100px; margin:24px auto; padding:16px }
+      header{ display:flex; justify-content:space-between; align-items:center; padding:12px 0; border-bottom:1px solid var(--line) }
+      .grid{ display:grid; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); gap:16px; margin-top:16px }
+      .token{ display:flex; justify-content:space-between; border:1px dashed var(--line); padding:8px 10px; border-radius:8px }
+    </style>
+  </head>
+  <body>
+    <div class="shell">
+      <header>
+        <strong>BOCC Shell (Preview)</strong>
+        <nav><a class="btn" href="#">Primary</a></nav>
+      </header>
+      <section class="grid">
+        <div class="card"><h3>Card</h3><p>Uses tokens for background, border, and radius.</p></div>
+        <div class="card"><h3>Button</h3><a class="btn" href="#">Try me</a></div>
+        <div class="card"><h3>Tokens</h3>
+          <div class="token"><span>accent-1</span><span style="background:var(--accent-1); width:24px; height:16px; display:inline-block"></span></div>
+          <div class="token"><span>accent-2</span><span style="background:var(--accent-2); width:24px; height:16px; display:inline-block"></span></div>
+        </div>
+      </section>
+    </div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+  </html>

--- a/design/storybook/package.json
+++ b/design/storybook/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bosonit-spec-kit-storybook",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --strictPort --port 5081"
+  },
+  "devDependencies": {
+    "vite": "^5.4.2",
+    "typescript": "^5.5.4"
+  }
+}

--- a/design/storybook/src/main.ts
+++ b/design/storybook/src/main.ts
@@ -1,0 +1,3 @@
+// Minimal boot for DOM-based stories
+console.log('Spec Kit Storybook (Lite) ready');
+

--- a/design/tokens.css
+++ b/design/tokens.css
@@ -1,0 +1,14 @@
+:root{
+  --color-bg:#0b0f13; --color-fg:#e6edf3; --color-muted:#9aa4ad; --line:#1c232b;
+  --accent-1:#7fc3ff; --accent-2:#9b7bff; --warn:#ffcc88; --ok:#7fffd4;
+  --radius-sm:8px; --radius-md:12px; --radius-lg:16px;
+  --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-6:24px; --space-8:32px;
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  --fs-1:12px; --fs-2:14px; --fs-3:16px; --fs-4:20px; --fs-5:28px; --fs-6:40px;
+  --easing:smoothstep cubic-bezier(.25,.1,.25,1); --dur-fast:120ms; --dur-med:240ms; --dur-slow:420ms;
+}
+
+.card{ background:#0f141a; border:1px solid var(--line); border-radius:var(--radius-md); padding:var(--space-4) }
+.btn{ display:inline-block; padding:10px 14px; border-radius:10px; background:linear-gradient(90deg,var(--accent-1),var(--accent-2)); color:#001428; font-weight:700; text-decoration:none }
+body{ background:var(--color-bg); color:var(--color-fg); font-family:var(--font-sans) }

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -1,0 +1,20 @@
+{
+  "colors": {
+    "bg": "#0b0f13",
+    "fg": "#e6edf3",
+    "muted": "#9aa4ad",
+    "line": "#1c232b",
+    "accent1": "#7fc3ff",
+    "accent2": "#9b7bff",
+    "warn": "#ffcc88",
+    "ok": "#7fffd4"
+  },
+  "radius": { "sm": 8, "md": 12, "lg": 16 },
+  "space": { "1": 4, "2": 8, "3": 12, "4": 16, "6": 24, "8": 32 },
+  "font": {
+    "sans": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial",
+    "mono": "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace"
+  },
+  "typeScale": { "1": 12, "2": 14, "3": 16, "4": 20, "5": 28, "6": 40 },
+  "motion": { "easing": "cubic-bezier(.25,.1,.25,1)", "dur": { "fast": 120, "med": 240, "slow": 420 } }
+}

--- a/scripts/issues-from-tasks.sh
+++ b/scripts/issues-from-tasks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Usage: GH_TOKEN=... REPO=owner/name scripts/issues-from-tasks.sh path/to/tasks.md
+FILE=${1:-}
+REPO=${REPO:-}
+if [[ -z "$FILE" || -z "$REPO" ]]; then echo "Usage: REPO=owner/name $0 path/to/tasks.md"; exit 2; fi
+if [[ ! -f "$FILE" ]]; then echo "File not found: $FILE"; exit 2; fi
+if [[ -z "${GH_TOKEN:-}" ]]; then echo "GH_TOKEN not set"; exit 2; fi
+mapfile -t LINES < <(grep -E '^- \[ \] |^- \[x\] ' "$FILE" | sed 's/^- \[[x ]\] //')
+for TITLE in "${LINES[@]}"; do
+  BODY=$(jq -Rs . <<< "$TITLE")
+  curl -sS -X POST \
+    -H "Authorization: Bearer $GH_TOKEN" \
+    -H 'Accept: application/vnd.github+json' \
+    https://api.github.com/repos/$REPO/issues \
+    -d "{\"title\":$BODY, \"labels\":[\"spec-task\"]}" >/dev/null
+  echo "[OK] Created: $TITLE"
+done


### PR DESCRIPTION
Adds design tokens (CSS+JSON), a minimal Storybook-lite, a CI spec gate, and a script to open issues from Spec Kit tasks. Establishes groundwork for BOCC theming + spec lifecycle gates.