### PR TITLE
ci(pages): include tokens.css in artifact

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Include tokens.css
+        run: cp design/tokens.css design/storybook/tokens.css
       - name: Upload static site
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
Copy design/tokens.css into the published storybook folder so the stylesheet loads on GH Pages.