### PR TITLE
chore: package tokens + publish to GH Packages

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,26 @@
+name: Publish Spec Tokens (GH Packages)
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@BosonIT-org'
+      - name: Validate package.json
+        run: node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"
+      - name: Publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm publish --access public || npm publish --access public --ignore-scripts

--- a/design/tokens.css
+++ b/design/tokens.css
@@ -1,4 +1,5 @@
 :root{
+  --focus:#94c7ff4d; --link:#b7d9ff; --link-hover:#e3eeff;
   --color-bg:#0b0f13; --color-fg:#e6edf3; --color-muted:#9aa4ad; --line:#1c232b;
   --accent-1:#7fc3ff; --accent-2:#9b7bff; --warn:#ffcc88; --ok:#7fffd4;
   --radius-sm:8px; --radius-md:12px; --radius-lg:16px;
@@ -12,3 +13,8 @@
 .card{ background:#0f141a; border:1px solid var(--line); border-radius:var(--radius-md); padding:var(--space-4) }
 .btn{ display:inline-block; padding:10px 14px; border-radius:10px; background:linear-gradient(90deg,var(--accent-1),var(--accent-2)); color:#001428; font-weight:700; text-decoration:none }
 body{ background:var(--color-bg); color:var(--color-fg); font-family:var(--font-sans) }
+
+/* Accessibility defaults */
+:where(a){ color:var(--link) }
+:where(a:hover){ color:var(--link-hover) }
+:where(a:focus-visible,.btn:focus-visible){ outline:3px solid var(--focus); outline-offset:2px; border-radius:8px }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@BosonIT-org/spec-kit-tokens",
+  "version": "0.1.0",
+  "description": "BosonIT Spec Kit design tokens (CSS + JSON)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BosonIT-org/Bosonit-spec-kit.git"
+  },
+  "license": "UNLICENSED",
+  "author": "BosonIT",
+  "files": [
+    "design/tokens.css",
+    "design/tokens.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "main": "design/tokens.json",
+  "style": "design/tokens.css",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  }
+}


### PR DESCRIPTION
Adds package.json and a publish workflow to ship design tokens (CSS+JSON) to GitHub Packages on release. Also introduces minor a11y variables and defaults in tokens.css (focus, link colors).